### PR TITLE
Minor Bug Fix in Example & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ int main() {
   }
 #pragma omp parallel for schedule(static, 12)
   for (int i = 0; i < 2000; i++) {
-    std::cout<<"value at "<<i<<": "<<sali.at(i)<<std::endl;
+    int val = 0;
+    sali.at(i, val);
+    std::cout<<"value at "<<i<<": "<<val<<std::endl;
   }
 
   return 0;

--- a/src/examples/example_multithread.cpp
+++ b/src/examples/example_multithread.cpp
@@ -22,7 +22,9 @@ int main() {
   }
 #pragma omp parallel for schedule(static, 12)
   for (int i = 0; i < 2000; i++) {
-    std::cout<<"value at "<<i<<": "<<sali.at(i)<<std::endl;
+    int val = 0;
+    sali.at(i, val);
+    std::cout<<"value at "<<i<<": "<<val<<std::endl;
   }
 
   return 0;


### PR DESCRIPTION
Dear Repository Owner,

Congratulations on having your paper accepted at SIGMOD 2024.
I enjoyed reading it as it was both highly interesting and engaging.

While attempting to conduct my own experiments, I noticed what seems to be a minor issue in the example source code. 
```
[ 50%] Building CXX object CMakeFiles/example_mt.dir/src/examples/example_multithread.cpp.o
SALI/src/examples/example_multithread.cpp: In function ‘int main()’:
SALI/src/examples/example_multithread.cpp:25:47: error: no matching function for call to ‘sali::SALI<int, int>::at(int&)’
   25 |     std::cout<<"value at "<<i<<": "<<sali.at(i)<<std::endl;
```

Though I'm not entirely certain, based on my understanding, it appears that it could be corrected as follows. 
```cpp
// example_multithread.cpp
#pragma omp parallel for schedule(static, 12)
  for (int i = 0; i < 2000; i++) {
    int val = 0;
    sali.at(i, val);
    std::cout<<"value at "<<i<<": "<<val<<std::endl;
  }
```
This modification seems to ensure that the build process works smoothly and that the results are accurate. 
Could you please check on this?

Best regards,
Minguk Choi